### PR TITLE
Add Impressum page linked from footer

### DIFF
--- a/public/impressum.html
+++ b/public/impressum.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <title>Impressum - Mathis Neunzig</title>
+    <link rel="stylesheet" href="css/default.css">
+    <link rel="stylesheet" href="css/layout.css">
+    <link rel="stylesheet" href="css/media-queries.css">
+  </head>
+  <body>
+    <div class="row">
+      <div class="twelve columns">
+        <h1>Impressum</h1>
+        <p>Angaben gemäß §5 TMG</p>
+        <p>Mathis Neunzig<br>Europaplatz 17<br>69115 Heidelberg</p>
+        <p>Kontakt:<br>
+          E-Mail: <a href="mailto:info@mathis-neunzig.de">info@mathis-neunzig.de</a>
+        </p>
+        <p>Verantwortlich für den Inhalt nach §55 Abs. 2 RStV:<br>
+          Mathis Neunzig
+        </p>
+        <p><a href="/">Zurück zur Startseite</a></p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -19,7 +19,10 @@ export default class Footer extends Component {
               })
             }
           </ul>
-          
+          <ul className="copyright">
+            <li><a href="/impressum.html">Impressum</a></li>
+          </ul>
+
         </div>
         <div id="go-top"><a className="smoothscroll" title="Back to Top" href="#home"><i className="icon-up-open" /></a></div>
       </div>


### PR DESCRIPTION
## Summary
- add dedicated `impressum.html` with contact details
- link the new page from the footer

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403b7b56048321bd270dee074972f4